### PR TITLE
makes shutdown-pool! public

### DIFF
--- a/src/overtone/at_at.clj
+++ b/src/overtone/at_at.clj
@@ -233,7 +233,7 @@
   (let [pool-info  @(:pool-atom pool)]
     (schedule-at pool-info fun delay-ms desc)))
 
-(defn- shutdown-pool!
+(defn shutdown-pool!
   [pool-info strategy]
   (case strategy
     :stop (shutdown-pool-gracefully! pool-info)


### PR DESCRIPTION
I may be missing something but I don't see any harm in making this public.  Being able to shutdown the thread pool (and not reset it) is important in my use case because I want to be able to release all the resources being used by my app.
